### PR TITLE
fix: enable EBO for vendored llvh simple_ilist on MSVC via build-time LLVM_DECLARE_EMPTY_BASES patch

### DIFF
--- a/crates/fft_support/build.rs
+++ b/crates/fft_support/build.rs
@@ -23,9 +23,10 @@ fn is_msvc_target() -> bool {
 /// Apply `patches/hermes-simple-ilist-empty-bases.patch` on the MSVC build
 /// path. Mirrors the same hook in `crates/hermes/build.rs`; both build
 /// scripts run independently so each must apply, but the function is
-/// idempotent (the second writer sees the attribute already present and
-/// returns early). See `crates/hermes/build.rs` and facebook/hermes#2012
-/// for the full diagnosis and the bump-behavior contract.
+/// idempotent (the second writer sees `LLVM_DECLARE_EMPTY_BASES simple_ilist`
+/// already present and returns early). See `crates/hermes/build.rs` and
+/// facebook/hermes#2012 for the full diagnosis and the bump-behavior
+/// contract.
 fn ensure_msvc_empty_bases_patch(hermes_root: &Path) {
     if !is_msvc_target() {
         return;
@@ -47,7 +48,13 @@ fn ensure_msvc_empty_bases_patch(hermes_root: &Path) {
             err
         )
     });
-    if original.contains("__declspec(empty_bases) simple_ilist") {
+    // Idempotency check accepts either marker: the macro-based form
+    // `LLVM_DECLARE_EMPTY_BASES simple_ilist` (upstreamed at hermes#2012) or
+    // the earlier inline `__declspec(empty_bases) simple_ilist` form. See
+    // crates/hermes/build.rs for the rationale.
+    if original.contains("LLVM_DECLARE_EMPTY_BASES simple_ilist")
+        || original.contains("__declspec(empty_bases) simple_ilist")
+    {
         return;
     }
 
@@ -81,7 +88,9 @@ fn ensure_msvc_empty_bases_patch(hermes_root: &Path) {
         // between our idempotency check and our `git apply`, the file is now
         // patched and we can skip silently rather than panicking.
         if let Ok(after) = std::fs::read_to_string(&target_path) {
-            if after.contains("__declspec(empty_bases) simple_ilist") {
+            if after.contains("LLVM_DECLARE_EMPTY_BASES simple_ilist")
+                || after.contains("__declspec(empty_bases) simple_ilist")
+            {
                 return;
             }
         }

--- a/crates/fft_support/build.rs
+++ b/crates/fft_support/build.rs
@@ -20,6 +20,94 @@ fn is_msvc_target() -> bool {
     matches!(env::var("CARGO_CFG_TARGET_ENV").as_deref(), Ok("msvc"))
 }
 
+/// Apply `patches/hermes-simple-ilist-empty-bases.patch` on the MSVC build
+/// path. Mirrors the same hook in `crates/hermes/build.rs`; both build
+/// scripts run independently so each must apply, but the function is
+/// idempotent (the second writer sees the attribute already present and
+/// returns early). See `crates/hermes/build.rs` and facebook/hermes#2012
+/// for the full diagnosis and the bump-behavior contract.
+fn ensure_msvc_empty_bases_patch(hermes_root: &Path) {
+    if !is_msvc_target() {
+        return;
+    }
+
+    let target_path = hermes_root.join("external/llvh/include/llvh/ADT/simple_ilist.h");
+    let manifest_dir = PathBuf::from(
+        env::var_os("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR is set by cargo"),
+    );
+    let patch_file = manifest_dir.join("../../patches/hermes-simple-ilist-empty-bases.patch");
+
+    println!("cargo:rerun-if-changed={}", patch_file.display());
+    println!("cargo:rerun-if-changed={}", target_path.display());
+
+    let original = std::fs::read_to_string(&target_path).unwrap_or_else(|err| {
+        panic!(
+            "MSVC build requires a patched llvh simple_ilist.h, but reading {} failed: {}",
+            target_path.display(),
+            err
+        )
+    });
+    if original.contains("__declspec(empty_bases) simple_ilist") {
+        return;
+    }
+
+    if !patch_file.exists() {
+        panic!(
+            "MSVC build expects {} but the file is missing — was patches/ pruned?",
+            patch_file.display()
+        );
+    }
+
+    // Skip canonicalize() — on Windows it returns the `\\?\` extended-length
+    // form which `git apply` rejects with "can't open patch". The path is
+    // already absolute (manifest_dir joined with a relative tail), and git
+    // resolves `..` components fine.
+    let output = std::process::Command::new("git")
+        .arg("apply")
+        .arg("--whitespace=nowarn")
+        .arg(&patch_file)
+        .current_dir(hermes_root)
+        .output()
+        .unwrap_or_else(|err| {
+            panic!(
+                "could not invoke `git apply` for the MSVC simple_ilist patch: {} (is git on PATH?)",
+                err
+            )
+        });
+
+    if !output.status.success() {
+        // Race-safe sibling: see crates/hermes/build.rs for the full reasoning.
+        // If a parallel build script already won the race and applied the patch
+        // between our idempotency check and our `git apply`, the file is now
+        // patched and we can skip silently rather than panicking.
+        if let Ok(after) = std::fs::read_to_string(&target_path) {
+            if after.contains("__declspec(empty_bases) simple_ilist") {
+                return;
+            }
+        }
+
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        panic!(
+            "Applying {} failed.\n\
+             stderr:\n{}\nstdout:\n{}\n\
+             This usually means the bundled Hermes submodule was bumped and\n\
+             external/llvh/include/llvh/ADT/simple_ilist.h no longer matches the\n\
+             patch's expected context. To resolve:\n\
+             \n\
+               1. If the upstream fix (facebook/hermes#2012) has landed in the new\n\
+                  submodule pin, this patch is unnecessary — delete the patch file\n\
+                  and the `ensure_msvc_empty_bases_patch` calls in build.rs.\n\
+             \n\
+               2. Otherwise, regenerate the patch against the new submodule revision\n\
+                  and overwrite patches/hermes-simple-ilist-empty-bases.patch.",
+            patch_file.display(),
+            stderr.trim(),
+            stdout.trim(),
+        );
+    }
+}
+
 fn cmake_profile_dir() -> &'static str {
     let profile = env::var("PROFILE").unwrap_or_default();
     let debug = env::var("DEBUG").unwrap_or_default();
@@ -111,6 +199,8 @@ fn configure_target_specific_cmake(config: &mut cmake::Config) {
 fn main() {
     emit_cpp_runtime_link();
     let hermes_root = detect_hermes_root();
+
+    ensure_msvc_empty_bases_patch(&hermes_root);
 
     println!(
         "cargo:rerun-if-changed={}",

--- a/crates/hermes/build.rs
+++ b/crates/hermes/build.rs
@@ -20,6 +20,126 @@ fn is_msvc_target() -> bool {
     matches!(env::var("CARGO_CFG_TARGET_ENV").as_deref(), Ok("msvc"))
 }
 
+/// Apply `patches/hermes-simple-ilist-empty-bases.patch` to the bundled llvh
+/// `simple_ilist.h` so MSVC actually performs Empty Base Optimization across
+/// the class's two empty bases. Same change being upstreamed at
+/// facebook/hermes#2012; we ship it as a patch file applied at build time
+/// until that PR lands and we can bump the submodule pin past it.
+///
+/// Without `__declspec(empty_bases)` MSVC pads each of `simple_ilist`'s two
+/// empty bases with one byte and pointer-aligns the result, shifting the
+/// embedded `Sentinel` member from offset 0 to offset 8. Code that takes
+/// `&simple_ilist` and treats it as `&Sentinel` (such as the Rust FFI iterator
+/// in `crates/hermes/src/parser/node.rs`) then iterates with the wrong head
+/// address: linked-list pointers stored by C++ point at `&Sentinel`, but the
+/// Rust side compares against `&simple_ilist`, so the circular list never
+/// terminates and the iterator dereferences the sentinel as if it were a real
+/// node. Manifests as `STATUS_ACCESS_VIOLATION 0xC0000005` during AST
+/// traversal on Windows. See facebook/hermes#2012 for the full diagnosis.
+///
+/// Behavior on Hermes submodule bumps:
+/// - Bump that doesn't touch `simple_ilist.h`: idempotency check sees no
+///   `__declspec(empty_bases)`, `git apply` runs cleanly, build proceeds.
+/// - Bump that includes the upstream fix (Hermes#2012 merged): idempotency
+///   check sees the attribute already present and returns early. The patch
+///   becomes unnecessary and can be removed at the maintainer's leisure.
+/// - Bump that changes `simple_ilist.h` in some other way: `git apply` fails
+///   with non-zero exit and we panic. Intentional — silently skipping would
+///   produce an unpatched binary that AVs at runtime, which is worse than a
+///   build error. The panic message points the maintainer at the patch file
+///   and at Hermes#2012 so the resolution path is obvious.
+///
+/// Gated on `is_msvc_target()` because GCC and Clang already collapse the
+/// empty bases without the attribute — Linux and macOS builds skip this
+/// entirely.
+fn ensure_msvc_empty_bases_patch(hermes_root: &Path) {
+    if !is_msvc_target() {
+        return;
+    }
+
+    let target_path = hermes_root.join("external/llvh/include/llvh/ADT/simple_ilist.h");
+    let manifest_dir = PathBuf::from(
+        env::var_os("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR is set by cargo"),
+    );
+    let patch_file = manifest_dir.join("../../patches/hermes-simple-ilist-empty-bases.patch");
+
+    println!("cargo:rerun-if-changed={}", patch_file.display());
+    println!("cargo:rerun-if-changed={}", target_path.display());
+
+    let original = std::fs::read_to_string(&target_path).unwrap_or_else(|err| {
+        panic!(
+            "MSVC build requires a patched llvh simple_ilist.h, but reading {} failed: {}",
+            target_path.display(),
+            err
+        )
+    });
+    if original.contains("__declspec(empty_bases) simple_ilist") {
+        // Already patched in this checkout, or upstream Hermes has landed
+        // facebook/hermes#2012 and we no longer need this hook.
+        return;
+    }
+
+    if !patch_file.exists() {
+        panic!(
+            "MSVC build expects {} but the file is missing — was patches/ pruned?",
+            patch_file.display()
+        );
+    }
+
+    // Skip canonicalize() — on Windows it returns the `\\?\` extended-length
+    // form which `git apply` rejects with "can't open patch". The path is
+    // already absolute (manifest_dir joined with a relative tail), and git
+    // resolves `..` components fine.
+    let output = std::process::Command::new("git")
+        .arg("apply")
+        .arg("--whitespace=nowarn")
+        .arg(&patch_file)
+        .current_dir(hermes_root)
+        .output()
+        .unwrap_or_else(|err| {
+            panic!(
+                "could not invoke `git apply` for the MSVC simple_ilist patch: {} (is git on PATH?)",
+                err
+            )
+        });
+
+    if !output.status.success() {
+        // Cargo runs build scripts of independent crates in parallel, so
+        // `crates/hermes/build.rs` and `crates/fft_support/build.rs` race on
+        // applying the same patch. The idempotency check earlier may have
+        // observed the file as unpatched while a sibling patcher was still
+        // mid-apply; by the time we run our own `git apply` the file is
+        // patched and git rejects ours. Re-read the file and skip silently
+        // if the attribute is now present — that's a successful race loss,
+        // not a real failure.
+        if let Ok(after) = std::fs::read_to_string(&target_path) {
+            if after.contains("__declspec(empty_bases) simple_ilist") {
+                return;
+            }
+        }
+
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        panic!(
+            "Applying {} failed.\n\
+             stderr:\n{}\nstdout:\n{}\n\
+             This usually means the bundled Hermes submodule was bumped and\n\
+             external/llvh/include/llvh/ADT/simple_ilist.h no longer matches the\n\
+             patch's expected context. To resolve:\n\
+             \n\
+               1. If the upstream fix (facebook/hermes#2012) has landed in the new\n\
+                  submodule pin, this patch is unnecessary — delete the patch file\n\
+                  and the `ensure_msvc_empty_bases_patch` calls in build.rs.\n\
+             \n\
+               2. Otherwise, regenerate the patch against the new submodule revision\n\
+                  and overwrite patches/hermes-simple-ilist-empty-bases.patch.",
+            patch_file.display(),
+            stderr.trim(),
+            stdout.trim(),
+        );
+    }
+}
+
 fn cmake_profile_dir() -> &'static str {
     let profile = env::var("PROFILE").unwrap_or_default();
     let debug = env::var("DEBUG").unwrap_or_default();
@@ -111,6 +231,8 @@ fn configure_target_specific_cmake(config: &mut cmake::Config) {
 fn main() {
     emit_cpp_runtime_link();
     let hermes_root = detect_hermes_root();
+
+    ensure_msvc_empty_bases_patch(&hermes_root);
 
     println!(
         "cargo:rerun-if-changed={}",

--- a/crates/hermes/build.rs
+++ b/crates/hermes/build.rs
@@ -21,33 +21,37 @@ fn is_msvc_target() -> bool {
 }
 
 /// Apply `patches/hermes-simple-ilist-empty-bases.patch` to the bundled llvh
-/// `simple_ilist.h` so MSVC actually performs Empty Base Optimization across
-/// the class's two empty bases. Same change being upstreamed at
-/// facebook/hermes#2012; we ship it as a patch file applied at build time
-/// until that PR lands and we can bump the submodule pin past it.
+/// so MSVC actually performs Empty Base Optimization across `simple_ilist`'s
+/// two empty bases. Same change being upstreamed at facebook/hermes#2012; we
+/// ship it as a patch file applied at build time until that PR lands and we
+/// can bump the submodule pin past it.
 ///
-/// Without `__declspec(empty_bases)` MSVC pads each of `simple_ilist`'s two
-/// empty bases with one byte and pointer-aligns the result, shifting the
-/// embedded `Sentinel` member from offset 0 to offset 8. Code that takes
-/// `&simple_ilist` and treats it as `&Sentinel` (such as the Rust FFI iterator
-/// in `crates/hermes/src/parser/node.rs`) then iterates with the wrong head
+/// The patch (a) adds the `LLVM_DECLARE_EMPTY_BASES` macro to llvh's
+/// `Compiler.h` (mirroring the existing `HERMES_EMPTY_BASES` one layer up;
+/// llvh cannot depend on Hermes), and (b) tags `simple_ilist` with that
+/// macro. Without it MSVC pads each of `simple_ilist`'s two empty bases with
+/// one byte and pointer-aligns the result, shifting the embedded `Sentinel`
+/// member from offset 0 to offset 8. Code that takes `&simple_ilist` and
+/// treats it as `&Sentinel` (such as the Rust FFI iterator in
+/// `crates/hermes/src/parser/node.rs`) then iterates with the wrong head
 /// address: linked-list pointers stored by C++ point at `&Sentinel`, but the
 /// Rust side compares against `&simple_ilist`, so the circular list never
-/// terminates and the iterator dereferences the sentinel as if it were a real
-/// node. Manifests as `STATUS_ACCESS_VIOLATION 0xC0000005` during AST
+/// terminates and the iterator dereferences the sentinel as if it were a
+/// real node. Manifests as `STATUS_ACCESS_VIOLATION 0xC0000005` during AST
 /// traversal on Windows. See facebook/hermes#2012 for the full diagnosis.
 ///
 /// Behavior on Hermes submodule bumps:
-/// - Bump that doesn't touch `simple_ilist.h`: idempotency check sees no
-///   `__declspec(empty_bases)`, `git apply` runs cleanly, build proceeds.
+/// - Bump that doesn't touch the patched files: idempotency check sees no
+///   marker, `git apply` runs cleanly, build proceeds.
 /// - Bump that includes the upstream fix (Hermes#2012 merged): idempotency
-///   check sees the attribute already present and returns early. The patch
-///   becomes unnecessary and can be removed at the maintainer's leisure.
-/// - Bump that changes `simple_ilist.h` in some other way: `git apply` fails
-///   with non-zero exit and we panic. Intentional — silently skipping would
-///   produce an unpatched binary that AVs at runtime, which is worse than a
-///   build error. The panic message points the maintainer at the patch file
-///   and at Hermes#2012 so the resolution path is obvious.
+///   check sees `LLVM_DECLARE_EMPTY_BASES simple_ilist` already present and
+///   returns early. The patch becomes unnecessary and can be removed at the
+///   maintainer's leisure.
+/// - Bump that changes the patched files in some other way: `git apply`
+///   fails with non-zero exit and we panic. Intentional — silently skipping
+///   would produce an unpatched binary that AVs at runtime, which is worse
+///   than a build error. The panic message points the maintainer at the
+///   patch file and at Hermes#2012 so the resolution path is obvious.
 ///
 /// Gated on `is_msvc_target()` because GCC and Clang already collapse the
 /// empty bases without the attribute — Linux and macOS builds skip this
@@ -73,9 +77,19 @@ fn ensure_msvc_empty_bases_patch(hermes_root: &Path) {
             err
         )
     });
-    if original.contains("__declspec(empty_bases) simple_ilist") {
-        // Already patched in this checkout, or upstream Hermes has landed
-        // facebook/hermes#2012 and we no longer need this hook.
+    // Idempotency check accepts either marker:
+    //   - `LLVM_DECLARE_EMPTY_BASES simple_ilist` is the macro-based form used
+    //     by the upstreamed facebook/hermes#2012 patch (mirroring the
+    //     HERMES_EMPTY_BASES pattern one layer up).
+    //   - `__declspec(empty_bases) simple_ilist` is the earlier inline form
+    //     this patch originally shipped with; recognized for backward compat
+    //     so existing patched checkouts keep building without a submodule
+    //     re-init.
+    // A match means the file is already patched in this checkout or upstream
+    // Hermes has landed the fix and we no longer need this hook.
+    if original.contains("LLVM_DECLARE_EMPTY_BASES simple_ilist")
+        || original.contains("__declspec(empty_bases) simple_ilist")
+    {
         return;
     }
 
@@ -113,7 +127,9 @@ fn ensure_msvc_empty_bases_patch(hermes_root: &Path) {
         // if the attribute is now present — that's a successful race loss,
         // not a real failure.
         if let Ok(after) = std::fs::read_to_string(&target_path) {
-            if after.contains("__declspec(empty_bases) simple_ilist") {
+            if after.contains("LLVM_DECLARE_EMPTY_BASES simple_ilist")
+                || after.contains("__declspec(empty_bases) simple_ilist")
+            {
                 return;
             }
         }

--- a/patches/hermes-simple-ilist-empty-bases.patch
+++ b/patches/hermes-simple-ilist-empty-bases.patch
@@ -1,49 +1,63 @@
-Subject: [PATCH] Fix: apply __declspec(empty_bases) to simple_ilist for MSVC
+Subject: [PATCH] Fix: enable EBO for simple_ilist on MSVC
 
-Mirrors facebook/hermes#2012. MSVC does not apply Empty Base Optimization
-across multiple empty bases by default; without `__declspec(empty_bases)`
-it pads each empty base with one byte and pointer-aligns the result,
-shifting the embedded `Sentinel` of `simple_ilist` from offset 0 to
-offset 8. That breaks any caller that treats the address of a
-`simple_ilist` as the address of its embedded sentinel — including
-fft's Rust FFI iterator at `crates/hermes/src/parser/node.rs`. GCC and
-Clang collapse the empty bases unconditionally, so the patch is gated
-on `_MSC_VER` and is a no-op on every other compiler.
+Mirrors facebook/hermes#2012. simple_ilist inherits from two empty bases
+(list_base_type and SpecificNodeAccess); without an explicit attribute
+MSVC does not collapse them, shifting the embedded Sentinel from offset
+0 to offset 8 and breaking layout-sensitive consumers — most visibly
+fft's Rust FFI iterator at crates/hermes/src/parser/node.rs.
 
-Applied at build time by `crates/hermes/build.rs` and
-`crates/fft_support/build.rs`. Idempotent: skipped automatically once
-the bundled Hermes is bumped past facebook/hermes#2012 (the
-`__declspec(empty_bases) simple_ilist` substring will already be
-present and the patcher returns early).
+Adds LLVM_DECLARE_EMPTY_BASES to llvh's Compiler.h (mirroring the
+existing HERMES_EMPTY_BASES one layer up; llvh cannot depend on Hermes)
+and applies it to simple_ilist. Recorded upstream at
+external/llvh/patches/simple-ilist-msvc-empty-bases.patch.
+
+Applied at build time by crates/hermes/build.rs and
+crates/fft_support/build.rs. Idempotent: skipped automatically once the
+bundled Hermes is bumped past facebook/hermes#2012 (the
+LLVM_DECLARE_EMPTY_BASES marker will already be present and the patcher
+returns early).
 
 diff --git a/external/llvh/include/llvh/ADT/simple_ilist.h b/external/llvh/include/llvh/ADT/simple_ilist.h
+index 6a59ddc7..e79877f0 100644
 --- a/external/llvh/include/llvh/ADT/simple_ilist.h
 +++ b/external/llvh/include/llvh/ADT/simple_ilist.h
-@@ -75,8 +75,27 @@ namespace llvh {
+@@ -75,8 +75,15 @@ namespace llvh {
  /// equivalent to the last.
  ///
  /// See \a is_valid_option for steps on adding a new option.
 +///
-+/// MSVC requires `__declspec(empty_bases)` to actually apply Empty Base
-+/// Optimization when a class has more than one empty base. `simple_ilist`
-+/// inherits from two empty helpers (`list_base_type` and `SpecificNodeAccess`),
-+/// and without this attribute MSVC pads each empty base with a byte and
-+/// pointer-aligns the result, shifting the embedded `Sentinel` member from
-+/// offset 0 to offset 8. That makes `&simple_ilist` and `&Sentinel` differ by
-+/// 8 bytes on MSVC, while GCC/Clang produce the layout where they coincide.
-+/// The shift is not visible through pure C++ list usage, but it breaks any
-+/// caller that treats the address of a `simple_ilist` as the address of its
-+/// sentinel — most notably FFI consumers and any code that compares an
-+/// iterator's stored node pointer against `&list` rather than against an
-+/// iterator obtained from `list.end()`. Mirrors the LLVM upstream pattern of
-+/// `__declspec(empty_bases)` on layout-sensitive containers.
-+#if defined(_MSC_VER)
-+template <typename T, class... Options>
-+class __declspec(empty_bases) simple_ilist
-+#else
++/// `simple_ilist` inherits from two empty helpers (`list_base_type` and
++/// `SpecificNodeAccess`). Without `LLVM_DECLARE_EMPTY_BASES` MSVC fails to
++/// collapse them and shifts the embedded `Sentinel` from offset 0 to offset
++/// 8, breaking callers that rely on `&list == &Sentinel` — most visibly FFI
++/// consumers and any code comparing an iterator's stored node pointer
++/// against `&list` rather than against an iterator from `list.end()`.
  template <typename T, class... Options>
- class simple_ilist
-+#endif
+-class simple_ilist
++class LLVM_DECLARE_EMPTY_BASES simple_ilist
      : ilist_detail::compute_node_options<T, Options...>::type::list_base_type,
        ilist_detail::SpecificNodeAccess<
            typename ilist_detail::compute_node_options<T, Options...>::type> {
+diff --git a/external/llvh/include/llvh/Support/Compiler.h b/external/llvh/include/llvh/Support/Compiler.h
+index 34173110..1dc671e5 100644
+--- a/external/llvh/include/llvh/Support/Compiler.h
++++ b/external/llvh/include/llvh/Support/Compiler.h
+@@ -108,6 +108,18 @@
+ #define LLVM_LIBRARY_VISIBILITY
+ #endif
+ 
++/// LLVM_DECLARE_EMPTY_BASES - Force MSVC to apply Empty Base Optimization
++/// across multiple empty bases. By default MSVC pads each empty base with
++/// one byte and pointer-aligns the result, which shifts member offsets and
++/// breaks any code that relies on a derived object's address coinciding
++/// with the address of its first member (e.g. layout-sensitive containers
++/// and FFI consumers).
++#ifdef _MSC_VER
++#define LLVM_DECLARE_EMPTY_BASES __declspec(empty_bases)
++#else
++#define LLVM_DECLARE_EMPTY_BASES
++#endif
++
+ #if defined(__GNUC__)
+ #define LLVM_PREFETCH(addr, rw, locality) __builtin_prefetch(addr, rw, locality)
+ #else

--- a/patches/hermes-simple-ilist-empty-bases.patch
+++ b/patches/hermes-simple-ilist-empty-bases.patch
@@ -1,0 +1,49 @@
+Subject: [PATCH] Fix: apply __declspec(empty_bases) to simple_ilist for MSVC
+
+Mirrors facebook/hermes#2012. MSVC does not apply Empty Base Optimization
+across multiple empty bases by default; without `__declspec(empty_bases)`
+it pads each empty base with one byte and pointer-aligns the result,
+shifting the embedded `Sentinel` of `simple_ilist` from offset 0 to
+offset 8. That breaks any caller that treats the address of a
+`simple_ilist` as the address of its embedded sentinel — including
+fft's Rust FFI iterator at `crates/hermes/src/parser/node.rs`. GCC and
+Clang collapse the empty bases unconditionally, so the patch is gated
+on `_MSC_VER` and is a no-op on every other compiler.
+
+Applied at build time by `crates/hermes/build.rs` and
+`crates/fft_support/build.rs`. Idempotent: skipped automatically once
+the bundled Hermes is bumped past facebook/hermes#2012 (the
+`__declspec(empty_bases) simple_ilist` substring will already be
+present and the patcher returns early).
+
+diff --git a/external/llvh/include/llvh/ADT/simple_ilist.h b/external/llvh/include/llvh/ADT/simple_ilist.h
+--- a/external/llvh/include/llvh/ADT/simple_ilist.h
++++ b/external/llvh/include/llvh/ADT/simple_ilist.h
+@@ -75,8 +75,27 @@ namespace llvh {
+ /// equivalent to the last.
+ ///
+ /// See \a is_valid_option for steps on adding a new option.
++///
++/// MSVC requires `__declspec(empty_bases)` to actually apply Empty Base
++/// Optimization when a class has more than one empty base. `simple_ilist`
++/// inherits from two empty helpers (`list_base_type` and `SpecificNodeAccess`),
++/// and without this attribute MSVC pads each empty base with a byte and
++/// pointer-aligns the result, shifting the embedded `Sentinel` member from
++/// offset 0 to offset 8. That makes `&simple_ilist` and `&Sentinel` differ by
++/// 8 bytes on MSVC, while GCC/Clang produce the layout where they coincide.
++/// The shift is not visible through pure C++ list usage, but it breaks any
++/// caller that treats the address of a `simple_ilist` as the address of its
++/// sentinel — most notably FFI consumers and any code that compares an
++/// iterator's stored node pointer against `&list` rather than against an
++/// iterator obtained from `list.end()`. Mirrors the LLVM upstream pattern of
++/// `__declspec(empty_bases)` on layout-sensitive containers.
++#if defined(_MSC_VER)
++template <typename T, class... Options>
++class __declspec(empty_bases) simple_ilist
++#else
+ template <typename T, class... Options>
+ class simple_ilist
++#endif
+     : ilist_detail::compute_node_options<T, Options...>::type::list_base_type,
+       ilist_detail::SpecificNodeAccess<
+           typename ilist_detail::compute_node_options<T, Options...>::type> {


### PR DESCRIPTION
## Summary

Apply the [`LLVM_DECLARE_EMPTY_BASES`](https://github.com/facebook/hermes/pull/2012) macro to the vendored llvh `simple_ilist` so MSVC actually performs Empty Base Optimization across the class's two empty bases. Same change merged upstream at [`facebook/hermes#2012`](https://github.com/facebook/hermes/pull/2012) on 2026-05-11 ([`facebook/hermes@768bab2a`](https://github.com/facebook/hermes/commit/768bab2a5d3a4e0a5eae2793c09b908cce813ee3)); we ship it as a unified-diff patch file under `patches/` applied at build time, until the submodule pin moves past the merge commit (currently pinned to [`5749d170`](https://github.com/facebook/hermes/commit/5749d170c81d0928e5b5d3676abeb422dfa77c66), 207 commits behind `static_h` HEAD per `git rev-list --count`).

This is the structural fix for the Windows `STATUS_ACCESS_VIOLATION 0xC0000005` reported in #16 and softened at the symptom level in #17. With this PR's fix in place, #17 is no longer needed — Hermes does not actually produce null `SMLoc`s in this code path; the apparent nulls were the layout-corrupted iterator reading the sentinel-as-Node.

## Why this PR

Without the attribute, MSVC pads each of `simple_ilist`'s two empty bases with one byte and pointer-aligns the result, shifting the embedded `Sentinel` member from offset 0 to offset 8. The Rust FFI in [`crates/hermes/src/parser/node.rs`](https://github.com/jbroma/fast-flow-transform/blob/main/crates/hermes/src/parser/node.rs) wraps a `*const NodeList = *const simple_ilist<Node>` returned by accessors like `hermes_get_FunctionDeclaration_params(n)`, then iterates by reading `next` pointers and comparing each one against the head pointer it was given:

```rust
impl<'a> std::iter::Iterator for NodeIterator<'a> {
    fn next(&mut self) -> Option<Self::Item> {
        self.cur = unsafe { (*self.cur).next };
        if self.cur == self.head { None } else { Some(...) }
    }
}
```

On Linux/Clang and macOS the comparison succeeds — `Sentinel` is at offset 0 of `simple_ilist`, so `&list == &list.Sentinel` — and iteration terminates. On Windows MSVC the C++ side stores `&list.Sentinel` (offset 8) in the linked-list pointers while Rust received `&list` (offset 0); the comparison never matches, the iterator walks past the end of the list, dereferences the sentinel as if it were a real `Node`, and trips `STATUS_ACCESS_VIOLATION 0xC0000005` on the first field load.

Layout traces (`eprintln!` in `NodeIterator::next`) on the failing build show the off-by-8 signature directly:

```
NodeIterator::next: head=0x4e5fe8 cur(was)=0x4e5d18 read next=0x4e5ff0
                                                              ^^^^^^^^
                                                  head + 8 (offset of `Sentinel`)
```

After the patch the same trace shows `read next == head` and iteration terminates correctly.

## How the patch is applied

The patch lives at `patches/hermes-simple-ilist-empty-bases.patch` and is byte-aligned with the post-revision form of `facebook/hermes#2012` — it adds the `LLVM_DECLARE_EMPTY_BASES` macro to llvh's `Compiler.h` and applies it to `simple_ilist`. Applied by `crates/hermes/build.rs` and `crates/fft_support/build.rs` via `git apply` against the bundled Hermes submodule. The hook is:

- **Target-gated.** Skipped entirely when `is_msvc_target()` is false. GCC and Clang already collapse the empty bases without the attribute, so Linux and macOS builds are unaffected.
- **Idempotent (dual-marker).** Returns early when *either* `LLVM_DECLARE_EMPTY_BASES simple_ilist` (the upstreamed macro form) *or* `__declspec(empty_bases) simple_ilist` (the legacy inline form, kept for backward compatibility with checkouts patched by an earlier version of this hook) is already present in the file. Both forms compile to identical machine code on MSVC, so checkouts patched by the legacy form keep building without a forced submodule re-init.
- **Race-safe.** Cargo runs `crates/hermes/build.rs` and `crates/fft_support/build.rs` in parallel, so both can pass the idempotency check while a sibling is still mid-`git apply`. If our own `git apply` then fails, we re-read the file: if either marker is now present, we skip silently (sibling won the race); only a real conflict still panics.
- **Loud on conflict.** If `git apply` fails for a non-race reason (Hermes refactored `simple_ilist.h` or `Compiler.h` and the patch's context lines no longer match), the build script panics with a message that names the patch file, surfaces git's stderr, and points at the two resolution paths: drop the patch (upstream merged 2026-05-11 at [`facebook/hermes@768bab2a`](https://github.com/facebook/hermes/commit/768bab2a5d3a4e0a5eae2793c09b908cce813ee3)), or regenerate it. Silently skipping would produce an unpatched binary that AVs at runtime — worse than a build error.

The patch file itself is a unified diff that mirrors the merged change at [`facebook/hermes#2012`](https://github.com/facebook/hermes/pull/2012) ([`facebook/hermes@768bab2a`](https://github.com/facebook/hermes/commit/768bab2a5d3a4e0a5eae2793c09b908cce813ee3)), so the file is reviewable in isolation rather than buried in `build.rs` string literals.

## Behavior on Hermes submodule bumps

| Scenario | Behavior |
|---|---|
| Bump that doesn't touch `simple_ilist.h` or `Compiler.h` | Idempotency check sees no marker; `git apply` runs cleanly; build proceeds. |
| Bump past [`facebook/hermes@768bab2a`](https://github.com/facebook/hermes/commit/768bab2a5d3a4e0a5eae2793c09b908cce813ee3) (merge commit of `facebook/hermes#2012`, 2026-05-11) | Idempotency check sees `LLVM_DECLARE_EMPTY_BASES simple_ilist` already present; returns early. The patch can be removed at any time. |
| Existing checkout patched by the legacy inline form | Idempotency check sees `__declspec(empty_bases) simple_ilist` and returns early. No forced re-init. |
| Bump that changes the patched files in some other way | `git apply` rejects the patch; build.rs panics with a message that includes the patch file path, git's `patch does not apply` stderr, and a two-path remediation block. The build never produces an unpatched binary that would AV at runtime. |

## Validation matrix

| # | Scenario | Expected | Result |
|---|---|---|---|
| 1 | Windows MSVC, clean submodule, fresh build | `cargo build --release` succeeds, `cargo test --release --workspace` passes | ✅ build clean in **36.13 s** from clean state (full cmake reconfigure); 136 tests pass |
| 2 | Windows MSVC, idempotent re-run (no submodule restore) | Second build skips re-application | ✅ pass (~40 s incremental, no re-apply) |
| 3 | Windows MSVC, conflict simulation (stray comment ahead of `simple_ilist` template) | Panic with `patch does not apply` + two-path remediation | ✅ pass (exit 101, message as documented) |
| 4 | Linux WSL Ubuntu 22.04 — C++ side build | All 10 Hermes static libs build cleanly via `cmake` (`libLLVHSupport.a`, `libhermesParser.a`, etc.); macro resolves to empty | ✅ pass (verified `.a` artefacts in `~/fft-linux-validate-target/release/build/hermes-*/out/build/`) |
| 5 | Linux full `cargo test --release --workspace` | Full Rust workspace passes via target gate | ⚠️ **Pre-existing rustc 1.93.1 ICE in `fft_ast` lint pass** (`#0 [lint_mod] linting module 'context'`) blocks the test from completing. The ICE is unrelated to my patch — `fft_ast` is a Rust-only crate that doesn't include the C++ headers I changed. C++ correctness on Linux is covered by Test 4. |
| 6 | Hermes#2012 already-merged simulation (macro form pre-applied) | Idempotency returns early via `LLVM_DECLARE_EMPTY_BASES simple_ilist` marker | ✅ pass (static analysis of `crates/hermes/build.rs:74-91`) |
| 7 | Legacy-form pre-applied (existing checkout) | Idempotency returns early via `__declspec(empty_bases) simple_ilist` marker | ✅ pass (static analysis) |
| 8 | Patch file missing | Panic with `was patches/ pruned?` | ✅ pass |
| 9 | Submodule target file missing | Panic with read failure message | ✅ pass |
| 10 | Patch file corrupt (not a valid diff) | git apply parse error → panic | ✅ pass |
| 11 | Partial pre-application (comment block present but macro not yet) | Patch context shifted → `git apply` rejects → panic | ✅ pass |
| 12 | mingw target (`target_env = "gnu"`) | Skipped via `is_msvc_target()` gate | ✅ pass (static analysis — function is `matches!(env::var("CARGO_CFG_TARGET_ENV").as_deref(), Ok("msvc"))`) |
| 13 | Concurrent race between `crates/hermes/build.rs` and `crates/fft_support/build.rs` | Race-safety re-read after `git apply` failure: if either marker now present, skip silently | ✅ pass (3 back-to-back clean builds with target dirs wiped between each — all 3 succeed) |
| 14 | `cargo fmt --all --check` | clean | ✅ clean |
| 15 | End-to-end: napi binding rebuilt + plugged into `onejs/one`'s Vite-native bundler | Full RN bundle returned, no segfault | ✅ HTTP 200, **5.01 MB** iOS bundle in 1.31 s; **5.03 MB** android bundle in 1.04 s. Previously the dev server segfaulted on the first request. |
| — | CI on this PR (linux-only, ubuntu-24.04) | All gates green (patcher skipped via target gate) | ⏳ pending — first-time-contributor workflow approval |

## Notes

- The patch file is a 2-hunk unified diff against `external/llvh/include/llvh/Support/Compiler.h` and `external/llvh/include/llvh/ADT/simple_ilist.h`, byte-aligned with the merged form of [`facebook/hermes#2012`](https://github.com/facebook/hermes/pull/2012) at [`facebook/hermes@768bab2a`](https://github.com/facebook/hermes/commit/768bab2a5d3a4e0a5eae2793c09b908cce813ee3). Reviewing #2012 is equivalent to reviewing this patch's content.
- The `patches/` directory is new in this repo; this PR introduces both the convention and the first patch.
- This PR can be reverted as soon as the Hermes submodule pin is bumped past [`facebook/hermes@768bab2a`](https://github.com/facebook/hermes/commit/768bab2a5d3a4e0a5eae2793c09b908cce813ee3) — the patcher's idempotency check turns it into a no-op the first time the upstream `simple_ilist` already has the macro.
- #17 (cvt_smloc graceful fallback) is no longer needed once this PR lands; the original assert at `convert.rs:120` is correct because Hermes does not produce null `SMLoc`s in this path. I'll leave the call on whether to merge or close #17 to the maintainer.

Closes / supersedes #16's downstream-segfault diagnostic. `facebook/hermes#2012` (the upstream architectural fix) is already merged at [`facebook/hermes@768bab2a`](https://github.com/facebook/hermes/commit/768bab2a5d3a4e0a5eae2793c09b908cce813ee3); this PR is the bridge until fft's Hermes submodule pin moves past it.

