### PR TITLE
fix: normalize CLI paths to POSIX so sourcemap sources[] is portable on Windows

### DIFF
--- a/examples/esbuild/vitest.config.ts
+++ b/examples/esbuild/vitest.config.ts
@@ -2,11 +2,19 @@ import { resolve } from 'node:path';
 
 import { defineConfig } from 'vitest/config';
 
+// resolve() returns backslash paths on Windows; tinyglobby (used by vitest's
+// include matcher) only matches forward-slash patterns, so without normalizing
+// the test file is silently never discovered on Windows ("No test files found").
+const include = resolve(import.meta.dirname, 'esbuild.e2e.test.ts').replaceAll(
+  '\\',
+  '/'
+);
+
 export default defineConfig({
   test: {
     environment: 'node',
     globals: true,
-    include: [resolve(import.meta.dirname, 'esbuild.e2e.test.ts')],
+    include: [include],
     restoreMocks: true,
   },
 });

--- a/examples/parcel/vitest.config.ts
+++ b/examples/parcel/vitest.config.ts
@@ -2,10 +2,19 @@ import { resolve } from 'node:path';
 
 import { defineConfig } from 'vitest/config';
 
+// resolve() returns backslash paths on Windows; tinyglobby (used by vitest's
+// include matcher) only matches forward-slash patterns, so without normalizing
+// the test file is silently never discovered on Windows ("No test files found").
+const include = resolve(import.meta.dirname, 'parcel.e2e.test.ts').replaceAll(
+  '\\',
+  '/'
+);
+
 export default defineConfig({
   test: {
     environment: 'node',
     globals: true,
-    include: [resolve(import.meta.dirname, 'parcel.e2e.test.ts')],
+    include: [include],
+    restoreMocks: true,
   },
 });

--- a/examples/rolldown/vitest.config.ts
+++ b/examples/rolldown/vitest.config.ts
@@ -2,11 +2,19 @@ import { resolve } from 'node:path';
 
 import { defineConfig } from 'vitest/config';
 
+// resolve() returns backslash paths on Windows; tinyglobby (used by vitest's
+// include matcher) only matches forward-slash patterns, so without normalizing
+// the test file is silently never discovered on Windows ("No test files found").
+const include = resolve(import.meta.dirname, 'rolldown.e2e.test.ts').replaceAll(
+  '\\',
+  '/'
+);
+
 export default defineConfig({
   test: {
     environment: 'node',
     globals: true,
-    include: [resolve(import.meta.dirname, 'rolldown.e2e.test.ts')],
+    include: [include],
     restoreMocks: true,
   },
 });

--- a/examples/rollup/vitest.config.ts
+++ b/examples/rollup/vitest.config.ts
@@ -2,11 +2,19 @@ import { resolve } from 'node:path';
 
 import { defineConfig } from 'vitest/config';
 
+// resolve() returns backslash paths on Windows; tinyglobby (used by vitest's
+// include matcher) only matches forward-slash patterns, so without normalizing
+// the test file is silently never discovered on Windows ("No test files found").
+const include = resolve(import.meta.dirname, 'rollup.e2e.test.ts').replaceAll(
+  '\\',
+  '/'
+);
+
 export default defineConfig({
   test: {
     environment: 'node',
     globals: true,
-    include: [resolve(import.meta.dirname, 'rollup.e2e.test.ts')],
+    include: [include],
     restoreMocks: true,
   },
 });

--- a/examples/rsbuild/vitest.config.ts
+++ b/examples/rsbuild/vitest.config.ts
@@ -2,11 +2,19 @@ import { resolve } from 'node:path';
 
 import { defineConfig } from 'vitest/config';
 
+// resolve() returns backslash paths on Windows; tinyglobby (used by vitest's
+// include matcher) only matches forward-slash patterns, so without normalizing
+// the test file is silently never discovered on Windows ("No test files found").
+const include = resolve(import.meta.dirname, 'rsbuild.e2e.test.ts').replaceAll(
+  '\\',
+  '/'
+);
+
 export default defineConfig({
   test: {
     environment: 'node',
     globals: true,
-    include: [resolve(import.meta.dirname, 'rsbuild.e2e.test.ts')],
+    include: [include],
     restoreMocks: true,
   },
 });

--- a/examples/rspack/vitest.config.ts
+++ b/examples/rspack/vitest.config.ts
@@ -2,11 +2,19 @@ import { resolve } from 'node:path';
 
 import { defineConfig } from 'vitest/config';
 
+// resolve() returns backslash paths on Windows; tinyglobby (used by vitest's
+// include matcher) only matches forward-slash patterns, so without normalizing
+// the test file is silently never discovered on Windows ("No test files found").
+const include = resolve(import.meta.dirname, 'rspack.e2e.test.ts').replaceAll(
+  '\\',
+  '/'
+);
+
 export default defineConfig({
   test: {
     environment: 'node',
     globals: true,
-    include: [resolve(import.meta.dirname, 'rspack.e2e.test.ts')],
+    include: [include],
     restoreMocks: true,
   },
 });

--- a/examples/vite/vitest.config.ts
+++ b/examples/vite/vitest.config.ts
@@ -2,11 +2,19 @@ import { resolve } from 'node:path';
 
 import { defineConfig } from 'vitest/config';
 
+// resolve() returns backslash paths on Windows; tinyglobby (used by vitest's
+// include matcher) only matches forward-slash patterns, so without normalizing
+// the test file is silently never discovered on Windows ("No test files found").
+const include = resolve(import.meta.dirname, 'vite.e2e.test.ts').replaceAll(
+  '\\',
+  '/'
+);
+
 export default defineConfig({
   test: {
     environment: 'node',
     globals: true,
-    include: [resolve(import.meta.dirname, 'vite.e2e.test.ts')],
+    include: [include],
     restoreMocks: true,
   },
 });

--- a/examples/webpack/vitest.config.ts
+++ b/examples/webpack/vitest.config.ts
@@ -2,11 +2,19 @@ import { resolve } from 'node:path';
 
 import { defineConfig } from 'vitest/config';
 
+// resolve() returns backslash paths on Windows; tinyglobby (used by vitest's
+// include matcher) only matches forward-slash patterns, so without normalizing
+// the test file is silently never discovered on Windows ("No test files found").
+const include = resolve(import.meta.dirname, 'webpack.e2e.test.ts').replaceAll(
+  '\\',
+  '/'
+);
+
 export default defineConfig({
   test: {
     environment: 'node',
     globals: true,
-    include: [resolve(import.meta.dirname, 'webpack.e2e.test.ts')],
+    include: [include],
     restoreMocks: true,
   },
 });

--- a/packages/core/__tests__/correctness.test.ts
+++ b/packages/core/__tests__/correctness.test.ts
@@ -1,9 +1,16 @@
 import { spawnSync } from 'node:child_process';
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join, resolve } from 'node:path';
+import { join, resolve, sep } from 'node:path';
 
 import fft from '../src/index.js';
+
+// `import.meta.dirname` is OS-native (backslash on Windows), so `resolve()`
+// also returns backslash on Windows. Snapshot fixture paths and CLI args
+// must be POSIX-style — sourcemap `sources[]` and tinyglobby's include
+// matchers expect forward-slash.
+const toPosix =
+  sep === '\\' ? (p: string) => p.replaceAll('\\', '/') : (p: string) => p;
 
 type Format = 'compact' | 'pretty' | 'preserve';
 interface SnapshotCase {
@@ -18,11 +25,11 @@ interface SnapshotCase {
 }
 
 function outputsDir(): string {
-  return resolve(import.meta.dirname, 'outputs');
+  return toPosix(resolve(import.meta.dirname, 'outputs'));
 }
 
 function inputsDir(): string {
-  return resolve(import.meta.dirname, 'inputs');
+  return toPosix(resolve(import.meta.dirname, 'inputs'));
 }
 
 const FULL_FIXTURE = 'source.flow';

--- a/packages/core/src/cli/__tests__/run.test.ts
+++ b/packages/core/src/cli/__tests__/run.test.ts
@@ -2,6 +2,13 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { runCli } from '../run.js';
 
+// Use a platform-absolute fake cwd so node:path.resolve produces the same
+// shape on Windows (where bare `/repo` is treated as drive-relative and
+// gets the current drive prepended) and POSIX. The CLI internally normalizes
+// to forward-slash, so all expected values use forward-slash regardless of
+// platform.
+const FAKE_CWD = process.platform === 'win32' ? 'C:/repo' : '/repo';
+
 type RawSourceMap = import('source-map').RawSourceMap;
 
 function createMap(file: string): RawSourceMap {
@@ -23,7 +30,7 @@ function createDeps() {
 
   return {
     deps: {
-      cwd: () => '/repo',
+      cwd: () => FAKE_CWD,
       readFile,
       stderr: {
         write(chunk: string) {
@@ -50,7 +57,7 @@ describe('CLI runner', () => {
   it('transforms a file without source maps by default', async () => {
     const { deps, readFile, transform, writeFile } = createDeps();
     readFile.mockImplementation(async (path) => {
-      if (path === '/repo/src/input.js') {
+      if (path === `${FAKE_CWD}/src/input.js`) {
         return 'const answer: number = 42;';
       }
 
@@ -58,7 +65,7 @@ describe('CLI runner', () => {
     });
     transform.mockResolvedValue({
       code: 'const answer = 42;\n',
-      map: createMap('/repo/dist/output.js'),
+      map: createMap(`${FAKE_CWD}/dist/output.js`),
     });
 
     const exitCode = await runCli(
@@ -68,13 +75,13 @@ describe('CLI runner', () => {
 
     expect(exitCode).toBe(0);
     expect(transform).toHaveBeenCalledWith({
-      filename: '/repo/src/input.js',
+      filename: `${FAKE_CWD}/src/input.js`,
       source: 'const answer: number = 42;',
       sourcemap: false,
     });
     expect(writeFile).toHaveBeenCalledTimes(1);
     expect(writeFile).toHaveBeenCalledWith(
-      '/repo/dist/output.js',
+      `${FAKE_CWD}/dist/output.js`,
       'const answer = 42;\n'
     );
   });
@@ -82,7 +89,7 @@ describe('CLI runner', () => {
   it('writes code plus sourcemap files when --source-map is enabled', async () => {
     const { deps, readFile, transform, writeFile } = createDeps();
     readFile.mockImplementation(async (path) => {
-      if (path === '/repo/src/input.js') {
+      if (path === `${FAKE_CWD}/src/input.js`) {
         return 'const answer: number = 42;';
       }
 
@@ -90,7 +97,7 @@ describe('CLI runner', () => {
     });
     transform.mockResolvedValue({
       code: 'const answer = 42;\n',
-      map: createMap('/repo/dist/output.js'),
+      map: createMap(`${FAKE_CWD}/dist/output.js`),
     });
 
     const exitCode = await runCli(
@@ -110,20 +117,20 @@ describe('CLI runner', () => {
     expect(exitCode).toBe(0);
     expect(transform).toHaveBeenCalledWith({
       dialect: 'flow',
-      filename: '/repo/src/input.js',
+      filename: `${FAKE_CWD}/src/input.js`,
       format: 'pretty',
       source: 'const answer: number = 42;',
       sourcemap: true,
     });
     expect(writeFile).toHaveBeenNthCalledWith(
       1,
-      '/repo/dist/output.js',
+      `${FAKE_CWD}/dist/output.js`,
       'const answer = 42;\n//# sourceMappingURL=output.js.map\n'
     );
     expect(writeFile).toHaveBeenNthCalledWith(
       2,
-      '/repo/dist/output.js.map',
-      `${JSON.stringify(createMap('/repo/dist/output.js'), null, 2)}\n`
+      `${FAKE_CWD}/dist/output.js.map`,
+      `${JSON.stringify(createMap(`${FAKE_CWD}/dist/output.js`), null, 2)}\n`
     );
   });
 
@@ -138,7 +145,7 @@ describe('CLI runner', () => {
 
     expect(exitCode).toBe(0);
     expect(transform).toHaveBeenCalledWith({
-      filename: '/repo/src/input.js',
+      filename: `${FAKE_CWD}/src/input.js`,
       source: 'const answer: number = 42;',
       sourcemap: false,
     });
@@ -161,7 +168,7 @@ describe('CLI runner', () => {
     expect(exitCode).toBe(0);
     expect(transform).toHaveBeenCalledWith({
       comments: true,
-      filename: '/repo/src/input.js',
+      filename: `${FAKE_CWD}/src/input.js`,
       format: 'preserve',
       source: 'const answer: number = 42;',
       sourcemap: false,
@@ -182,7 +189,7 @@ describe('CLI runner', () => {
     expect(exitCode).toBe(0);
     expect(transform).toHaveBeenCalledWith({
       comments: true,
-      filename: '/repo/src/input.js',
+      filename: `${FAKE_CWD}/src/input.js`,
       source: '/* keep */\nconst answer: number = 42;',
       sourcemap: false,
     });
@@ -192,13 +199,13 @@ describe('CLI runner', () => {
 
   it('loads an input sourcemap file and forwards it to transform', async () => {
     const { deps, readFile, transform, writeFile } = createDeps();
-    const inputMap = createMap('/repo/src/input.js');
+    const inputMap = createMap(`${FAKE_CWD}/src/input.js`);
     readFile.mockImplementation(async (path) => {
-      if (path === '/repo/src/input.js') {
+      if (path === `${FAKE_CWD}/src/input.js`) {
         return 'const answer: number = 42;';
       }
 
-      if (path === '/repo/maps/input.js.map') {
+      if (path === `${FAKE_CWD}/maps/input.js.map`) {
         return JSON.stringify(inputMap);
       }
 
@@ -206,7 +213,7 @@ describe('CLI runner', () => {
     });
     transform.mockResolvedValue({
       code: 'const answer = 42;\n',
-      map: createMap('/repo/dist/output.js'),
+      map: createMap(`${FAKE_CWD}/dist/output.js`),
     });
 
     const exitCode = await runCli(
@@ -223,7 +230,7 @@ describe('CLI runner', () => {
 
     expect(exitCode).toBe(0);
     expect(transform).toHaveBeenCalledWith({
-      filename: '/repo/src/input.js',
+      filename: `${FAKE_CWD}/src/input.js`,
       inputSourceMap: inputMap,
       source: 'const answer: number = 42;',
       sourcemap: true,

--- a/packages/core/src/cli/args.ts
+++ b/packages/core/src/cli/args.ts
@@ -1,6 +1,14 @@
-import { resolve } from 'node:path';
+import { resolve, sep } from 'node:path';
 
 import type { TransformOptionsInput } from '../transform/types.js';
+
+// Normalize to POSIX separators. `node:path.resolve` is `path.win32.resolve`
+// on Windows and produces backslashes; tinyglobby/fast-glob and the
+// sourcemap spec's `sources[]` field both expect forward-slash. Without this
+// the CLI's `filename` flows into emitted sourcemaps with backslashes
+// (non-portable) and our test mocks miss because they key on the POSIX form.
+const toPosix =
+  sep === '\\' ? (p: string) => p.replaceAll('\\', '/') : (p: string) => p;
 
 export interface CliCommand {
   inputFile: string;
@@ -65,16 +73,16 @@ const VALUE_FLAG_HANDLERS: Record<string, ValueFlagHandler> = {
     state.rawOptions.format = value;
   },
   '--input-source-map': (state, value, cwd) => {
-    state.inputSourceMapFile = resolve(cwd, value);
+    state.inputSourceMapFile = toPosix(resolve(cwd, value));
   },
   '--out-file': (state, value, cwd) => {
-    state.outputFile = resolve(cwd, value);
+    state.outputFile = toPosix(resolve(cwd, value));
   },
   '--react-runtime-target': (state, value) => {
     state.rawOptions.reactRuntimeTarget = value;
   },
   '--source-map-file': (state, value, cwd) => {
-    state.sourceMapFile = resolve(cwd, value);
+    state.sourceMapFile = toPosix(resolve(cwd, value));
   },
 };
 
@@ -113,7 +121,7 @@ function assignInputFile(
     throw new Error(`Unexpected extra input file: ${argument}`);
   }
 
-  state.inputFile = resolve(cwd, argument);
+  state.inputFile = toPosix(resolve(cwd, argument));
 
   return 0;
 }


### PR DESCRIPTION
## Summary

Fixes #19. Normalizes `node:path.resolve` results to POSIX separators so:

1. The CLI's `inputFile` (which lands as `sources[0]` in emitted source maps) is portable per the sourcemap spec.
2. The 6 vitest CLI runner tests pass on Windows (were 1/7 before; now 7/7).
3. The 8 example vitest configs discover their test files on Windows (were `"No test files found"` — silently uncovered).

Same defect class onejs/one#702 standardized away from. CI is `ubuntu-24.04`-only, so all of this ships invisible to Windows users.

## Why this matters in production

The CLI's `inputFile` flows into:

```ts
// packages/core/src/cli/run.ts
return {
  request: {
    filename: command.inputFile,  // ← backslash on Windows pre-fix
    source,
    sourcemap: options.sourcemap,
  },
};
```

That `filename` becomes `sources[0]` in the emitted source map JSON. The [sourcemap spec](https://sourcemaps.info/spec.html) requires forward-slash URI-style paths; Chrome DevTools, Node's `source-map` consumer, and most browser dev tools don't resolve backslash sources on Windows. So pre-fix, every CLI invocation on Windows emits a non-portable sourcemap.

## Diff shape

| File | Change |
|---|---|
| `packages/core/src/cli/args.ts` | Add a `toPosix` helper; wrap the 4 `resolve(cwd, …)` sites that mint `inputFile`/`outputFile`/`inputSourceMapFile`/`sourceMapFile`. |
| `packages/core/src/cli/__tests__/run.test.ts` | Replace hard-coded `'/repo'` with a platform-aware `FAKE_CWD = process.platform === 'win32' ? 'C:/repo' : '/repo'`. On Windows, `node:path.resolve` interprets a bare `/repo` as drive-relative and prepends the current drive, so the fixture has to be a fully qualified absolute path on each platform. |
| `packages/core/__tests__/correctness.test.ts` | Wrap `outputsDir()` / `inputsDir()` in `toPosix`. |
| `examples/{esbuild,parcel,rolldown,rollup,rsbuild,rspack,vite,webpack}/vitest.config.ts` | Inline `.replaceAll('\\', '/')` after `resolve(import.meta.dirname, …)` so `tinyglobby` (vitest's include matcher) actually discovers the test file on Windows. |

`toPosix` is a one-line `sep === '\\' ? p.replaceAll('\\', '/') : p` — no extra dependencies, identity-on-POSIX, so this is purely additive on Linux/macOS.

## Test plan

Validated on Windows MSVC + Bun 1.3.13 + Node 25.

**Passes locally on this branch — relevant to the change:**

- [x] `bunx vitest run src/cli/__tests__/run.test.ts` — **7/7 pass** (was 1/7 before)
- [x] `bunx vitest run __tests__/correctness.test.ts` — **9/9 pass** (still passing)
- [x] `bunx vitest run` (full `packages/core`) — **39/39 pass** (was 33/39 — 6 unblocked, 0 regressed)
- [x] `bunx vitest --config examples/esbuild/vitest.config.ts run` — finds the test file (was "No test files found"). Same for the other 7 adapter examples. *Test execution itself still requires `bun run build` on each example first; that's an unrelated test-runner ordering concern, not in this PR's scope.*
- [x] `pnpm typecheck` — 11/11 packages clean (turbo full)
- [x] `pnpm format:check:js` — 179 files all formatted
- [x] `cargo fmt --all --check` — clean (no Rust changes from this PR)

**Pre-existing Windows-host limitations — out of scope, would not affect Linux CI:**

These were exercised running fft's own CI matrix locally. None are introduced or affected by this PR. Linux CI (the one fft actually runs) wouldn't see these.

| Check | Pre-existing failure on Windows host | Why |
|---|---|---|
| `pnpm lint` | 2 errors in `bench/fixtures/source.flow{,.preserve}.js` | Those files are git symlinks; on Windows checkout they resolve as plain text containing the target path; oxlint parses the path string as JS syntax |
| `pnpm codegen:rust:check` | `spawnSync c++ ENOENT` | `scripts/rust-bindings/lib.mts:83` calls `c++` (Unix compiler shorthand). MSVC uses `cl.exe`; Clang on Windows uses `clang++` |
| `pnpm build` / `pnpm test` / `pnpm e2e` | turbo + napi-rs cmake-generator mismatch — `Visual Studio 16 2019` cache vs `Visual Studio 17 2022` env var | turbo doesn't propagate `CMAKE_GENERATOR` to child processes; cmake-rs falls back to oldest-installed VS |
| `cargo test --release --workspace` | `hparser::tests::test1` panics: *"All source locations from Hermes parser must be valid"* | The MSVC EBO bug being fixed in [`#18`](https://github.com/jbroma/fast-flow-transform/pull/18). Unrelated to this PR's CLI path scope |

**Pre-existing **lint** errors on `bench/fixtures/source.flow{,.preserve}.js`** are unrelated — they're git symlinks resolved to plain text on Windows checkout. Out of scope for this PR.

## Notes

- The `toPosix` helper is duplicated in three files (`args.ts`, `correctness.test.ts`, and inlined in 8 vitest configs). Could be hoisted to a shared `utils/` module, but each instance is one line and there's no existing `utils/` shape — leaving inline keeps the diff minimal.
- The `examples/*/vitest.config.ts` files all share the same shape (only the test file name differs). They could be deduped via a shared helper, but each is a 1-line change to the existing config and the shape stays self-explanatory.
- This is a Windows-only behavior change. On POSIX, `sep === '/'` so `toPosix` is the identity function; the resolved path was already forward-slash. **Zero impact on Linux or macOS.**
