### PR TITLE
ci: run compatibility tests on Windows

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -140,7 +140,7 @@ jobs:
 
   windows-compat:
     name: windows-compat
-    runs-on: windows-latest
+    runs-on: windows-2022
     env:
       CMAKE_GENERATOR: Visual Studio 17 2022
       CMAKE_GENERATOR_PLATFORM: x64

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -137,3 +137,34 @@ jobs:
 
       - name: Run end-to-end tests
         run: pnpm e2e
+
+  windows-compat:
+    name: windows-compat
+    runs-on: windows-latest
+    env:
+      CMAKE_GENERATOR: Visual Studio 17 2022
+      CMAKE_GENERATOR_PLATFORM: x64
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - name: Set up PR CI
+        uses: ./.github/actions/setup-pr-ci
+
+      - name: Build
+        run: pnpm build
+
+      - name: Run Rust tests
+        run: cargo test --workspace
+
+      - name: Run package tests
+        run: pnpm test
+
+      - name: Run end-to-end tests
+        run: pnpm e2e
+
+      - name: Run CLI end-to-end tests
+        run: pnpm --filter '@fft-tests/cli' e2e

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -140,7 +140,7 @@ jobs:
     name: build-${{ matrix.name }}
     needs: prepare-publish
     if: ${{ needs.prepare-publish.result == 'success' }}
-    runs-on: windows-latest
+    runs-on: windows-2022
     strategy:
       fail-fast: false
       matrix:

--- a/turbo.json
+++ b/turbo.json
@@ -11,6 +11,7 @@
     },
     "fast-flow-transform#build": {
       "dependsOn": ["^build"],
+      "env": ["CMAKE_GENERATOR", "CMAKE_GENERATOR_PLATFORM"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "$TURBO_ROOT$/Cargo.toml",


### PR DESCRIPTION
## Summary

- add a Windows x64/MSVC compatibility job to PR CI
- run the native build, Rust tests, package tests, bundler E2E tests, and the otherwise-excluded CLI E2E package
- declare the CMake generator variables in Turbo so strict environment filtering forwards and hashes them
- pin PR and release Windows builds to `windows-2022`, matching their explicit Visual Studio 2022 generator

## Why

PR checks previously executed only on Ubuntu. The release workflow compiled Windows artifacts but never executed them, leaving Windows-only native-layout and path-handling regressions invisible until release or downstream use.

GitHub moved `windows-latest` to Windows Server 2025/Visual Studio 2026 in June 2026. This repository explicitly uses `Visual Studio 17 2022`, so both PR and release builds now use the matching `windows-2022` image.

## Validation

- `git diff --check`
- parsed both changed workflows successfully with Ruby YAML
- targeted Oxfmt check passed
- Turbo dry-run confirms `CMAKE_GENERATOR` and `CMAKE_GENERATOR_PLATFORM` are forwarded and hashed for `fast-flow-transform#build`
- Linux lint, formatting, typecheck, build, Rust tests, package tests, and E2E checks pass
- Windows reaches the native addon and bundler builds, then fails consistently at `crates/fft/src/hparser/convert.rs:120`: `All source locations from Hermes parser must be valid`

That Windows failure is intentional baseline evidence: CI plumbing is working and now exposes the MSVC/Hermes EBO defect addressed structurally by #18. Once this PR lands, refreshing #18 should provide the red-to-green proof for its fix; #17 remains a symptom-level fallback.

Windows failure: https://github.com/jbroma/fast-flow-transform/actions/runs/29250401487/job/86817318956
