### PR TITLE
test: normalize Vite example source root on Windows

### DIFF
--- a/examples/vite/vite.config.mjs
+++ b/examples/vite/vite.config.mjs
@@ -2,10 +2,10 @@ import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import fastFlowTransformVite from 'fast-flow-transform/vite';
-import { defineConfig, transformWithEsbuild } from 'vite';
+import { defineConfig, normalizePath, transformWithEsbuild } from 'vite';
 
 const PACKAGE_ROOT = dirname(fileURLToPath(import.meta.url));
-const SRC_ROOT = resolve(PACKAGE_ROOT, 'src');
+const SRC_ROOT = normalizePath(resolve(PACKAGE_ROOT, 'src'));
 const OUTDIR = resolve(PACKAGE_ROOT, 'dist');
 const JSX_FILTER = /\.[cm]?jsx?$/;
 


### PR DESCRIPTION
## Summary

Normalize the Vite example's `SRC_ROOT` with Vite's existing `normalizePath` helper.

Vite supplies normalized forward-slash module IDs on Windows, while `node:path.resolve` produces a backslash path. The mismatch made `id.startsWith(SRC_ROOT)` return false, so the example's follow-up JSX transform did not run and the Windows compatibility job failed with `Expression expected`.

## Dependency

This issue became visible after #18 fixed the earlier Hermes crash. Until #18 lands, this PR's standalone Windows job is expected to stop at that upstream failure before reaching the Vite build. Rerun `windows-compat` after #18 merges to validate the combined path.

## Validation

- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`
- `pnpm --filter @fft-examples/vite build`

`pnpm check` reached `codegen:rust:check`, which is not runnable under this machine's Node 20 because Node reports `ERR_UNKNOWN_FILE_EXTENSION` for the `.mts` generator. The checks above completed successfully before that unrelated local tooling failure.