### PR TITLE
test: run bundler steps through Windows shell

### DIFF
--- a/test/bundlers/build.mjs
+++ b/test/bundlers/build.mjs
@@ -30,6 +30,7 @@ function run(command, args) {
   return new Promise((resolve, reject) => {
     const child = spawn(command, args, {
       cwd: PACKAGE_ROOT,
+      shell: process.platform === 'win32',
       stdio: 'inherit',
     });
 


### PR DESCRIPTION
## Summary

- run bundler child processes through the platform shell on Windows
- allow Node to launch `pnpm.cmd` instead of failing with `spawn EINVAL`
- keep non-Windows behavior unchanged

## Context

The updated Windows compatibility run for #18 completed the MSVC build and all example builds, then failed in `@fft-bundler-tests#build` at `test/bundlers/build.mjs:31` because Windows command shims such as `pnpm.cmd` cannot be spawned directly without a shell.

Failed job: https://github.com/jbroma/fast-flow-transform/actions/runs/29258031669/job/86843482776

This PR uses the same `shell: process.platform === 'win32'` pattern already used by the repository's release and local-registry scripts.

## Validation

- `pnpm --filter @fft-bundler-tests build` — passed
- `pnpm check` — typecheck, lint, JS formatting, and Rust formatting passed; the final Rust-codegen check could not run locally because Node 20 rejects direct `.mts` execution with `ERR_UNKNOWN_FILE_EXTENSION`

## Dependency

The standalone Windows job on this PR may stop earlier at the existing Hermes MSVC assertion until #18 lands. After #18 merges, `windows-compat` is the platform regression test for this launcher fix.