### PR TITLE
ci: run Windows Rust tests in release mode

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -158,7 +158,7 @@ jobs:
         run: pnpm build
 
       - name: Run Rust tests
-        run: cargo test --workspace
+        run: cargo test --release --workspace
 
       - name: Run package tests
         run: pnpm test


### PR DESCRIPTION
## Summary

Run the Windows Rust workspace tests in release mode.

## Root cause

PR #18's latest `windows-compat` run passed the release package build, then `cargo test --workspace` rebuilt Hermes as Debug C++ libraries. MSVC linked those libraries against the debug CRT while Rust's MSVC target linked `msvcrt`, producing `LNK4098`, unresolved `__imp__calloc_dbg` / `__imp__CrtDbgReport`, and `LNK1120`.

Failed job: https://github.com/jbroma/fast-flow-transform/actions/runs/29259663794/job/86849674435

Using `cargo test --release --workspace` keeps the Rust tests and native Hermes libraries on the same runtime configuration. It also matches the release configuration shipped by the package and the validation already reported on #18.

## Validation

- `git diff --check`
- `pnpm format:check:js`

The Windows compatibility job is the platform regression check.

## Dependency

This PR is based on `main`, so its standalone Windows run may encounter the Hermes MSVC bug fixed by #18 before reaching the Rust test step. Once this lands and #18 updates from `main`, #18's `windows-compat` run will verify the corrected command.