### PR TITLE
test: use portable Vitest e2e paths

### DIFF
--- a/examples/esbuild/vitest.config.ts
+++ b/examples/esbuild/vitest.config.ts
@@ -1,12 +1,11 @@
-import { resolve } from 'node:path';
-
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
     environment: 'node',
     globals: true,
-    include: [resolve(import.meta.dirname, 'esbuild.e2e.test.ts')],
+    // Keep this relative because Vitest glob matching does not accept absolute Windows paths.
+    include: ['esbuild.e2e.test.ts'],
     restoreMocks: true,
   },
 });

--- a/examples/parcel/vitest.config.ts
+++ b/examples/parcel/vitest.config.ts
@@ -1,11 +1,10 @@
-import { resolve } from 'node:path';
-
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
     environment: 'node',
     globals: true,
-    include: [resolve(import.meta.dirname, 'parcel.e2e.test.ts')],
+    // Keep this relative because Vitest glob matching does not accept absolute Windows paths.
+    include: ['parcel.e2e.test.ts'],
   },
 });

--- a/examples/rolldown/vitest.config.ts
+++ b/examples/rolldown/vitest.config.ts
@@ -1,12 +1,11 @@
-import { resolve } from 'node:path';
-
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
     environment: 'node',
     globals: true,
-    include: [resolve(import.meta.dirname, 'rolldown.e2e.test.ts')],
+    // Keep this relative because Vitest glob matching does not accept absolute Windows paths.
+    include: ['rolldown.e2e.test.ts'],
     restoreMocks: true,
   },
 });

--- a/examples/rollup/vitest.config.ts
+++ b/examples/rollup/vitest.config.ts
@@ -1,12 +1,11 @@
-import { resolve } from 'node:path';
-
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
     environment: 'node',
     globals: true,
-    include: [resolve(import.meta.dirname, 'rollup.e2e.test.ts')],
+    // Keep this relative because Vitest glob matching does not accept absolute Windows paths.
+    include: ['rollup.e2e.test.ts'],
     restoreMocks: true,
   },
 });

--- a/examples/rsbuild/vitest.config.ts
+++ b/examples/rsbuild/vitest.config.ts
@@ -1,12 +1,11 @@
-import { resolve } from 'node:path';
-
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
     environment: 'node',
     globals: true,
-    include: [resolve(import.meta.dirname, 'rsbuild.e2e.test.ts')],
+    // Keep this relative because Vitest glob matching does not accept absolute Windows paths.
+    include: ['rsbuild.e2e.test.ts'],
     restoreMocks: true,
   },
 });

--- a/examples/rspack/vitest.config.ts
+++ b/examples/rspack/vitest.config.ts
@@ -1,12 +1,11 @@
-import { resolve } from 'node:path';
-
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
     environment: 'node',
     globals: true,
-    include: [resolve(import.meta.dirname, 'rspack.e2e.test.ts')],
+    // Keep this relative because Vitest glob matching does not accept absolute Windows paths.
+    include: ['rspack.e2e.test.ts'],
     restoreMocks: true,
   },
 });

--- a/examples/vite/vitest.config.ts
+++ b/examples/vite/vitest.config.ts
@@ -1,12 +1,11 @@
-import { resolve } from 'node:path';
-
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
     environment: 'node',
     globals: true,
-    include: [resolve(import.meta.dirname, 'vite.e2e.test.ts')],
+    // Keep this relative because Vitest glob matching does not accept absolute Windows paths.
+    include: ['vite.e2e.test.ts'],
     restoreMocks: true,
   },
 });

--- a/examples/webpack/vitest.config.ts
+++ b/examples/webpack/vitest.config.ts
@@ -1,12 +1,11 @@
-import { resolve } from 'node:path';
-
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
     environment: 'node',
     globals: true,
-    include: [resolve(import.meta.dirname, 'webpack.e2e.test.ts')],
+    // Keep this relative because Vitest glob matching does not accept absolute Windows paths.
+    include: ['webpack.e2e.test.ts'],
     restoreMocks: true,
   },
 });


### PR DESCRIPTION
## Summary

- use package-relative test filenames in all eight example Vitest configs
- remove unnecessary `node:path.resolve` imports
- document why the paths must remain relative

## Root cause

Vitest treats `include` values as glob patterns. Absolute Windows paths produced by `node:path.resolve` contain backslashes and did not match the example test files, so the Windows compatibility job exited with “No test files found.”

## Impact

Example e2e tests can be discovered consistently on Windows while retaining the same exact test-file scope on other platforms.

## Verification

- `pnpm --filter '@fft-examples/*' --parallel e2e` — all 8 test files passed
- `pnpm check` — typecheck, lint, JS formatting, and Rust formatting passed; final generated-bindings check was blocked locally by a stale CMake cache referencing a removed Nix-store path