### PR TITLE
test: make CLI e2e tests Windows-compatible

### DIFF
--- a/test/cli/cli.e2e.test.ts
+++ b/test/cli/cli.e2e.test.ts
@@ -81,7 +81,7 @@ describe('cli e2e', () => {
       await writeSuccessFixture(inputFile);
 
       const { stderr } = await runCli(
-        [inputFile, '--out-file', outputFile],
+        [inputFile, '--out-file', outputFile, '--source-map'],
         dir
       );
 
@@ -97,7 +97,9 @@ describe('cli e2e', () => {
       const inputFile = inputFilePath(dir);
       await writeFile(inputFile, '// @flow\nconst value: number = 1;\n');
 
-      await expect(runCli([inputFile], dir)).rejects.toMatchObject({
+      await expect(
+        runCli([inputFile, '--source-map'], dir)
+      ).rejects.toMatchObject({
         code: 1,
         stderr: 'Source maps require --out-file or --source-map-file.\n',
       });

--- a/test/cli/vitest.config.ts
+++ b/test/cli/vitest.config.ts
@@ -1,12 +1,11 @@
-import { resolve } from 'node:path';
-
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
     environment: 'node',
     globals: true,
-    include: [resolve(import.meta.dirname, 'cli.e2e.test.ts')],
+    // Keep this relative because Vitest glob matching does not accept absolute Windows paths.
+    include: ['cli.e2e.test.ts'],
     restoreMocks: true,
   },
 });


### PR DESCRIPTION
## Summary

- use a package-relative filename in the CLI Vitest config
- document why the include must remain relative
- pass `--source-map` in the two CLI e2e cases that exercise source-map behavior

## Root cause

Vitest treats `include` entries as glob patterns. The absolute Windows path created with `node:path.resolve` did not match `cli.e2e.test.ts`, so the Windows compatibility job stopped at test discovery.

After fixing discovery, both CLI e2e cases exposed stale assumptions that source maps are enabled by default. Current CLI behavior requires the explicit `--source-map` flag, as already covered by the CLI unit tests and help text.

## Verification

- audited all 11 Vitest configs; no absolute `include` patterns remain
- `pnpm --filter '@fft-tests/cli' e2e` — 2 tests passed
- `pnpm --filter fast-flow-transform test` — 39 tests passed
- `pnpm check` — typecheck, lint, and JS/Rust formatting passed; local generated-bindings check remains blocked by Node 20 not loading the repository's `.mts` script